### PR TITLE
fix for holiday chop bug

### DIFF
--- a/call-draft/src/utils.js
+++ b/call-draft/src/utils.js
@@ -28,6 +28,14 @@ export const getNextSaturday = coerceLuxonWrapper(day => day.plus({days: 6 - day
 // if given day is a Sunday, return the same Sunday
 export const getNextSunday = coerceLuxonWrapper(day => day.plus({days: 7 - day.weekday}))
 
+// get day prior to given day
+// if day is the same as the given day, return the same day
+export const getPriorXDay = (day, xDay) => coerceLuxon(day.minus({days: mod(day.weekday - xDay, 7) }))
+
+// get day after the given day
+// if day is the same as the given day, give the day the next week
+export const getNextXDay = (day, xDay) => coerceLuxon(day.plus({days: 7 - mod(day.weekday - xDay, 7) }))
+
 export const mod = function (n, m) {
   // mod function that handles negative numbers, usage: mod(num, modulous)
   return ((n % m) + m) % m;

--- a/call-draft/src/years/r2.js
+++ b/call-draft/src/years/r2.js
@@ -1,5 +1,5 @@
 import * as generic from './generic'
-import { getPriorSaturday, getPriorSunday, getNextSaturday, getNextSunday, sameDay, isPartOfHolidayWeekend } from '../utils'
+import { getPriorXDay, getNextXDay, getPriorSaturday, getPriorSunday, getNextSaturday, getNextSunday, sameDay, isPartOfHolidayWeekend } from '../utils'
 // shift is adjacent to an assigned night float week
 
 export const requiredShiftsURL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQNefnctzjWPpE-rWcQyTesFq0GJaYjMQ-Ux20oO8bx-3GgLTCT7vkOxMzD0nq_dTviZ_SIyMMmlqt8/pub?gid=1433333551&single=true&output=csv"
@@ -63,17 +63,16 @@ const querySaturdayNightCallWeekend = ({ assignedShifts }) => date => shift =>
     ),
   true
 )
+
 // shift is between two assigned CHOP weeks
 
 const queryCHOP = ({ CHOP }) => date => shift =>
-  CHOP.reduce((conflict, cp) =>
+  CHOP.reduce((conflict, cp) => 
     conflict + (
-    sameDay(getPriorSaturday(cp), date)
-    || sameDay(getPriorSunday(cp), date)
-    || sameDay(getNextSaturday(cp), date)
-    || sameDay(getNextSunday(cp), date)),
+    sameDay(getPriorXDay(cp, date.weekData.weekday), date)
+    || sameDay(getNextXDay(cp, date.weekData.weekday), date)),
   0
-) < 2
+  ) < 2
 
 
 const queryBelowHUPHolidayDayFloatCap     = generic.floatCap("DF HUP", true, PerShiftCaps)

--- a/call-draft/src/years/r3.js
+++ b/call-draft/src/years/r3.js
@@ -78,15 +78,14 @@ const querySaturdayNightCallWeekend = ({ assignedShifts }) => date => shift =>
 )
 
 // shift is between two assigned CHOP weeks
+
 const queryCHOP = ({ CHOP }) => date => shift =>
-  CHOP.reduce((conflict, cp) =>
+  CHOP.reduce((conflict, cp) => 
     conflict + (
-    sameDay(getPriorSaturday(cp), date)
-    || sameDay(getPriorSunday(cp), date)
-    || sameDay(getNextSaturday(cp), date)
-    || sameDay(getNextSunday(cp), date)),
+    sameDay(getPriorXDay(cp, date.weekData.weekday), date)
+    || sameDay(getNextXDay(cp, date.weekData.weekday), date)),
   0
-) < 2
+  ) < 2
 
 const queryBelowNeuroHolidayCap           = generic.floatCap("Neuro", true, PerShiftCaps)
 const queryBelowNeuroCap                  = generic.floatCap("Neuro", false, PerShiftCaps)


### PR DESCRIPTION
Generalized get[Next/Prior][Saturday/Sunday] into get[Next/Prior]XDay so that holidays on CHOP don't get missed by the CHOP filter